### PR TITLE
fix: keep cache and form changesets on a minor release

### DIFF
--- a/.changeset/cache-form-correctness.md
+++ b/.changeset/cache-form-correctness.md
@@ -1,7 +1,7 @@
 ---
-'@cleverbrush/server': major
-'@cleverbrush/client': major
-'@cleverbrush/deep': major
+'@cleverbrush/server': minor
+'@cleverbrush/client': minor
+'@cleverbrush/deep': minor
 '@cleverbrush/react-form': minor
 ---
 

--- a/.changeset/defaulted-form-fields.md
+++ b/.changeset/defaulted-form-fields.md
@@ -1,5 +1,5 @@
 ---
-'@cleverbrush/react-form': patch
+'@cleverbrush/react-form': minor
 ---
 
 Accept defaulted schema properties in typed Field, headless useField, and renderer schema bounds without losing value inference. Return a named TypedFormSystem so shared UI packages can export inferred registries while emitting declarations.

--- a/docs/cache-form-migration.md
+++ b/docs/cache-form-migration.md
@@ -3,6 +3,12 @@
 These changes are application-agnostic. Libraries do not choose an application's
 auth scope, UI kit, notifications, navigation behavior, or cache backend.
 
+This batch is scheduled as a coordinated **minor release** of the fixed package
+group. This release classification does not remove the compatibility changes
+below: external-cache users must coordinate the key-format migration, and
+consumers relying on previous `deepEqual` results must review those assumptions.
+The existing public form APIs remain available.
+
 ## Cache key migration (breaking)
 
 Previously, selected values were converted to strings and joined with delimiters.


### PR DESCRIPTION
## Description / Original request

Keep the recent Framework cache/form work on a minor release rather than a major release, and open a new PR before continuing Xpenser.

## What changed

- Change the server, client, and deep entries in `.changeset/cache-form-correctness.md` from `major` to `minor`; react-form remains `minor`.
- Change `.changeset/defaulted-form-fields.md` from `patch` to `minor`, consistent with this batch and its new public type exports.
- Add a release-classification note to the migration guide while retaining the cache-format and equality compatibility warnings.
- Leave the unrelated security-fix changeset, fixed-group configuration, package versions, lockfile, runtime code, and Xpenser unchanged.

## Reasoning

A major entry in the fixed release group schedules all 19 Framework packages for 5.0.0. The corrected release plan schedules all 19 for **4.5.0**, with no major releases. This changes the classification of this batch, not the general policy for future breaking changes.

The existing cache-key format and `deepEqual` behavior changes still require the documented consumer review/migration; relabeling the release does not make those compatibility concerns disappear.

## Type of change

- [x] Release metadata correction
- [x] Documentation update
- [ ] Runtime/API change

## Blog post

Skipped: internal release metadata, not a new user-facing feature.

## Screenshots / preview evidence

Not applicable: no UI or runtime change. Framework CI has no PR preview deployment; the generated release plan is the relevant evidence.

## Validation / Checklist

- [x] `npm ci --ignore-scripts`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — 4,267 tests across 178 files; no type errors
- [x] `npm run typecheck:schema-site`
- [x] `npm run typecheck:docs-site`
- [x] `npm run changeset -- status --output <temporary plan.json>`, with assertions that all 19 fixed-group packages are minor releases at 4.5.0 and that the complete plan has no major release
- [x] `git diff --check`
- [x] Existing changesets corrected; no new package behavior requiring an additional changeset or runtime test
- [x] GitHub [Lint, Build & Test (Node 24)](https://github.com/cleverbrush/framework/actions/runs/34405800285) — passed
- E2e, browser screenshots, and SigNoz: skipped; no runtime/deployment change.
- PR-ready notification: skipped; this release-metadata PR has no preview/deployed environment URL.

No packages versioned/published and no PR merged.